### PR TITLE
Fix jsonlint error on paralle.conf.json

### DIFF
--- a/src/test/resources/conf/parallel.conf.json
+++ b/src/test/resources/conf/parallel.conf.json
@@ -9,14 +9,19 @@
     "browserstack.debug": true
   },
 
-  "environments": [{
-    "browser": "chrome",
-  },{
-    "browser": "firefox",
-  },{
-    "browser": "safari",
-    "os": "OS X"
-  },{
-    "browser": "Internet Explorer",
-  }]
+  "environments": [
+    {
+      "browser": "chrome"
+    },
+    {
+      "browser": "firefox"
+    },
+    {
+      "browser": "safari",
+      "os": "OS X"
+    },
+    {
+      "browser": "Internet Explorer"
+    }
+  ]
 }


### PR DESCRIPTION
**BEFORE**
=======


```
$ jsonlint parallel.conf.json
Error: Parse error on line 13:
...owser": "chrome",  },{    "browser": "
----------------------^
Expecting 'STRING', got '}'
    at Object.parseError (/usr/local/lib/node_modules/jsonlint/lib/jsonlint.js:55:11)
    at Object.parse (/usr/local/lib/node_modules/jsonlint/lib/jsonlint.js:132:22)
    at parse (/usr/local/lib/node_modules/jsonlint/lib/cli.js:82:14)
    at main (/usr/local/lib/node_modules/jsonlint/lib/cli.js:135:14)
    at Object.<anonymous> (/usr/local/lib/node_modules/jsonlint/lib/cli.js:179:1)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10)
15:32:25 tchia@MB184-TChia:~/git/github/junit-browserstack/src/test/resources/conf (git:master+*:b9e54f7)  ruby-2.4.6
$
15:32:28 tchia@MB184-TChia:~/git/github/junit-browserstack/src/test/resources/conf (git:master+*:b9e54f7)  ruby-2.4.6
$
15:32:29 tchia@MB184-TChia:~/git/github/junit-browserstack/src/test/resources/conf (git:master+*:b9e54f7)  ruby-2.4.6
$
15:32:29 tchia@MB184-TChia:~/git/github/junit-browserstack/src/test/resources/conf (git:master+*:b9e54f7)  ruby-2.4.6


```
**AFTER**
=======

```
$ jsonlint parallel.conf.json
{
  "server": "hub-cloud.browserstack.com",
  "user": "BROWSERSTACK_USERNAME",
  "key": "BROWSERSTACK_ACCESS_KEY",
  "capabilities": {
    "build": "junit-browserstack",
    "name": "parallel_test",
    "browserstack.debug": true
  },
  "environments": [
    {
      "browser": "chrome"
    },
    {
      "browser": "firefox"
    },
    {
      "browser": "safari",
      "os": "OS X"
    },
    {
      "browser": "Internet Explorer"
    }
  ]
}

```