### PR TITLE
fix: assert case insensitive for ie browsers

### DIFF
--- a/src/test/java/com/browserstack/SingleTest.java
+++ b/src/test/java/com/browserstack/SingleTest.java
@@ -16,6 +16,6 @@ public class SingleTest extends BrowserStackJUnitTest {
     element.submit();
     Thread.sleep(5000);
 
-    assertEquals("BrowserStack - Google Search", driver.getTitle());
+    assertTrue(driver.getTitle().matches("(?i)BrowserStack - Google Search"));
   }
 }


### PR DESCRIPTION
https://browserstack.atlassian.net/browse/ACE-2219
Samsung Galaxy S10 Plus - pass     // device: 
Samsung Galaxy S9 - pass
Samsung Galaxy S8 - pass
Samsung Galaxy S7 - pass
OnePlus 9 - pass
Google Pixel 5 - pass
Xiaomi Redmi Note 9 - pass
iPhone SE 2020 - pass
iPhone 8 Plus - pass
iPhone 6S - pass
iPad Air 4 - pass
iPhone 12 - pass
iPad Pro 11 2020 - pass
On desktop:
Chrome on win7/8/8.1/10/mac - pass
Firefox on win7/8/8.1/10/mac - pass
ie6.0-11.0 on win7/8/8.1/10 - pass
edge on win10 - pass
safari 5.1,6,6.2,10.1,12.1,13.1 - pass